### PR TITLE
Fix tests and encryption logic

### DIFF
--- a/test.mjs
+++ b/test.mjs
@@ -1,30 +1,24 @@
-import { Keys } from './index.mjs'
+import assert from 'node:assert/strict'
+import Keys from './index.mjs'
 
 const k = new Keys()
-k.createKeys()
-console.log(`Created keys: ${JSON.stringify(crypto, null, 2)}`)
+await k.createKeys()
+console.log(`Created keys: ${JSON.stringify(k, null, 2)}`)
 
-// Sign a message'
-const message = 'this message'
-const sig = k.sign(message)
-console.log(`Signing message. ${message}, sig = ${sig}`)
+const msg = 'this message'
+const sig = await k.sign(msg)
+console.log(`Signing message. ${msg}, sig = ${sig}`)
+assert(await k.verify(msg, sig))
+console.log(`Verifying message: true ${sig} ${msg}`)
 
-// Verify a message
-const verified = k.verify(message, sig)
-console.log(`Verifying message: ${verified} ${sig} ${message}`)
-
-// Hash a message
-const hashed = k.hash('cb')
+const hashed = await k.hash('cb')
 console.log(`Hash a value: "cb" ${hashed}`)
 
-// Create encryption key
-const ek = k.createEncryptionKey()
+const ek = await k.createEncryptionKey()
 console.log(`Created encryption key: ${ek}`)
 
-// Encrypt a string
-let encryptedData = k.encrypt('text to hide')
-console.log(`Encrypt "text to hide": ${JSON.stringify(encryptedData)}`)
+let encrypted = await k.encrypt('text to hide')
+console.log(`Encrypt "text to hide": ${JSON.stringify(encrypted)}`)
 
-// Decrypt a string
-let decryptedData = k.decrypt(encryptedData)
-console.log(`Decrypt some data: ${decryptedData}`)
+let decrypted = await k.decrypt(encrypted)
+console.log(`Decrypt some data: ${decrypted}`)


### PR DESCRIPTION
## Summary
- load default export in tests
- await key creation calls
- use actual instance for logs
- check verification with `assert`
- fix AES-CTR usage in encryption helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684597c5062c83279b131f74bb8a9983