### PR TITLE
Fix signing-tools import example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,9 @@ Simpler api for EC keys
 
 ### Node
 ````js
-import { Signingtools } from 'signing-tools'
+import SigningTools from 'signing-tools'
 
-const crypto = new Signingtools()
+const crypto = new SigningTools()
 crypto.createKeys('844a4f5aaeef10dd522761264ae08ebe7b1a50d5dfaa18f48979c78b0e9a0f33')
 console.log(`Created keys: ${JSON.stringify(crypto, null, 2)}`)
 


### PR DESCRIPTION
## Summary
- fix import instructions in README

## Testing
- `npm test` *(fails: The requested module './index.mjs' does not provide an export named 'Keys')*

------
https://chatgpt.com/codex/tasks/task_e_684597c3a07883279558a1f183e0a517